### PR TITLE
Switch to using query string params instead of embedding URL in path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ URL-keyed SRPM details in Redis.
 
 The API server exposes two useful endpoints:
 
-    <API_BASE>/sources/<remote_artifact_url>
-    <API_BASE>/srpms/<remote_artifact_url>
+    <API_BASE>/sources/?remote_url=<remote_artifact_url>
+    <API_BASE>/srpms/?remote_url=<remote_artifact_url>
 
 The sources endpoint downloads the given remote artifact, hashes it
 with `sha256sum`, and reports the result as:

--- a/wsgi.py
+++ b/wsgi.py
@@ -3,7 +3,7 @@ import logging
 from functools import singledispatch
 
 import attr
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_restful import Resource, Api
 
 import srpminfo
@@ -50,16 +50,18 @@ def _handle_invalid_srpm(exc):
 # Set up the API endpoints
 ##############################################
 class Source(Resource):
-    def get(self, remote_url):
+    def get(self):
+        remote_url = request.args['remote_url']
         return jsonify(srpminfo.lookup_source(remote_url))
 
 class SRPM(Resource):
-    def get(self, remote_url):
+    def get(self):
+        remote_url = request.args['remote_url']
         return jsonify(srpminfo.lookup_srpm(remote_url))
 
 ENDPOINTS = (
-    ("srpms", SRPM, '/srpms/<path:remote_url>'),
-    ("sources", Source, '/sources/<path:remote_url>'),
+    ("srpms", SRPM, '/srpms/'),
+    ("sources", Source, '/sources/'),
 )
 
 RESOURCE_MAP = {}


### PR DESCRIPTION
When hosted by a WSGI adapter running on a full web server, such as Apache httpd server, the web server will usually normalise the full URL path as part of its protection against path traversal attacks. One consequence of this is that repeating slashes are collapsed and the URL path passed through to the WSGI application will only have a single slash where the original had two slashes together. Because web servers can do this, it isn't portable to include a target URI as part of the URL path. It is better to use a query string param if portability needed.

WSGI hosting mechanisms this affects include mod_wsgi, as well as CGI, SCGI and FASTCGI based WSGI adapters.