### PR TITLE
Switch to using mod_wsgi-express instead of gunicorn.

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,13 @@
+import mod_wsgi.server
+
+mod_wsgi.server.start(
+  '--log-to-terminal',
+  '--log-level', 'info',
+  '--access-log',
+  '--port', '8080',
+  '--trust-proxy-header', 'X-Forwarded-For',
+  '--trust-proxy-header', 'X-Forwarded-Port',
+  '--trust-proxy-header', 'X-Forwarded-Proto',
+  '--application-type', 'module',
+  '--entry-point', 'wsgi'
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-gunicorn
 Flask
 flask-restful
 sarge
@@ -6,3 +5,4 @@ attrs
 requests
 dogpile.cache
 redis
+mod_wsgi

--- a/wsgi.py
+++ b/wsgi.py
@@ -87,7 +87,9 @@ def _setup_cache_backend():
     redis_host = os.environ.get("REDIS_HOST", "redis")
     srpminfo.configure_cache(redis_host)
 
-# Run setup outside the __main__ guard so it also runs under gunicorn
+# Run setup outside the __main__ guard so it also runs under a WSGI
+# server which imports this as a module, rather than it being run as
+# the main script.
 _setup_logging()
 _setup_cache_backend()
 


### PR DESCRIPTION
Switch to using mod_wsgi-express instead of gunicorn.

This would only be able to merged once #1 is done to switch to query string params for declaring the remote URL for the SRPM package to query.